### PR TITLE
update vite plugin

### DIFF
--- a/vite/index.js
+++ b/vite/index.js
@@ -20,14 +20,14 @@ const vueJsx = require('@vitejs/plugin-vue-jsx')
 //   }
 // }
 
-function veauryVitePlugins({type, vueJsxInclude, vueJsxExclude, vueOptions = {}, vueJsxOptions: initVueJsxOptions = {}, reactOptions = {}}) {
+function veauryVitePlugins({type, vueJsxInclude = null, vueJsxExclude = null, vueOptions = {}, vueJsxOptions: initVueJsxOptions = {}, reactOptions = {}}) {
 
   let vueJsxOptions = {...initVueJsxOptions}
   if (type === 'react') {
-    vueJsxOptions.include = [/vue&type=script&lang\.[tj]sx?$/, /vue&type=script&setup=true&lang\.[tj]sx?$/, /[/\\]vue_app[\\/$]+/]
+    vueJsxOptions.include = vueJsxInclude || [/vue&type=script&lang\.[tj]sx?$/, /vue&type=script&setup=true&lang\.[tj]sx?$/, /[/\\]vue_app[\\/$]+/]
   }
   if (type === 'vue') {
-    vueJsxOptions.exclude = [/[/\\]react_app[\\/$]+/]
+    vueJsxOptions.exclude = vueJsxExclude || [/[/\\]react_app[\\/$]+/]
   }
   if (type === 'custom') {
     if (vueJsxInclude) {


### PR DESCRIPTION
type 为 vue 时，支持自定义 react 组件文件目录

设置 默认 vueJsxInclude 和 vueJsxExclude，避免vite.config.ts 使用type 为 vue 或 react 时 ts报错。