### PR TITLE
Fixed creatReactMissVue typo

### DIFF
--- a/types/veaury.d.ts
+++ b/types/veaury.d.ts
@@ -55,7 +55,7 @@ export const lazyVueInReact: (asyncImport: Promise<any>, options?: options) => a
 export const lazyReactInVue: (asyncImport: Promise<any> | defineAsyncComponentOptions, options?: options) => any;
 export const VueContainer: ReactComponent;
 export const injectPropsFromWrapper: injectPropsFromWrapper;
-export const creatReactMissVue: (ReactMissVueOptions: ReactMissVueOptions) => createReactMissVueReturn;
+export const createReactMissVue: (ReactMissVueOptions: ReactMissVueOptions) => createReactMissVueReturn;
 export const getReactNode: (VueElement: VNode | SlotFunction) => ReactNode;
 export const getVNode: (ReactElement: ReactNode) => VNode;
 export const RenderReactNode: VueComponent;


### PR DESCRIPTION
There was a typo in `types/veaury.d.ts` where it was incorrectly exporting `createReactMissVue` as `creatReactMissVue`. This was fixed in veaury@2.2.6 but reintroduced with this commit https://github.com/gloriasoft/veaury/commit/f972a2ba93d02da50072db271e8f5add26cc9033