### PR TITLE
feat: JSX Namespace in Vue 3.4.0 and Later Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1167,6 +1167,8 @@ index 5c5d343..a850f38 100644
 ```
 
 node_modules/@vue/runtime-dom/dist/runtime-dom.d.ts(@vue/runtime-dom@3.2.37)  
+> Starting from Vue 3.4, Vue no longer implicitly registers the global JSX namespace. The patch path should be `node_modules/vue/jsx-runtime/index.d.ts`
+
 ```diff
 diff --git a/node_modules/@vue/runtime-dom/dist/runtime-dom.d.ts b/node_modules/@vue/runtime-dom/dist/runtime-dom.d.ts
 index 3366f5a..b9eacc6 100644

--- a/README_zhcn.md
+++ b/README_zhcn.md
@@ -1102,6 +1102,8 @@ index 5c5d343..a850f38 100644
 ```
 
 node_modules/@vue/runtime-dom/dist/runtime-dom.d.ts(@vue/runtime-dom@3.2.37)
+> 从 Vue 3.4 开始，Vue 不再隐式注册全局 `JSX` 命名空间，patch 的路径应为 `node_modules/vue/jsx-runtime/index.d.ts`
+
 ```diff
 diff --git a/node_modules/@vue/runtime-dom/dist/runtime-dom.d.ts b/node_modules/@vue/runtime-dom/dist/runtime-dom.d.ts
 index 3366f5a..b9eacc6 100644


### PR DESCRIPTION
Improve the documentation regarding scenarios involving Vue 3.4.0 and later versions when using TypeScript.