### PR TITLE
fix: d.ts declare vue not @vue/runtime-core

### DIFF
--- a/types/veaury.d.ts
+++ b/types/veaury.d.ts
@@ -76,7 +76,7 @@ export const lazyPureReactInVue: typeof lazyReactInVue;
 export const lazyPureVueInReact: typeof lazyVueInReact;
 export const injectSyncUpdateForPureReactInVue: (ReactComponent: ReactComponent, syncUpdateHooks: SyncUpdateHooks) => SyncUpdateStates;
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
     interface ComponentCustomProperties {
         __veauryReactRef__?: any;
     }


### PR DESCRIPTION
Hi and thanks for this cool library!

I am having a similar issue to the one described in https://github.com/intlify/vue-i18n/issues/1403: Using `$t()` in my templates produces an error like "Property '$t' does not exist on type ..."

I haven't fully wrapped my head around the problem, but it seems to be the use of `declare module '@vue/runtime-core` in the `d.ts` file, where it should instead be `declare module 'vue'`, as per https://vuejs.org/api/utility-types.html#componentcustomproperties

Different plugins are interfering with each other somehow. One workaround in my case seemed to be to downgrade vue-router to 4.4.0. But the reasonable fix must be to update the module declaration in each package.

I have tested the suggested change using `patch-package` successfully in my project.