### PR TITLE
Implement automatic kebab-case to camelCase conversion

### DIFF
--- a/src/applyReactInVue.js
+++ b/src/applyReactInVue.js
@@ -3,6 +3,7 @@ import applyVueInReact from "./applyVueInReact"
 import { setOptions } from "./options"
 import { h as createElement, getCurrentInstance, reactive, Fragment as VueFragment, Comment } from 'vue'
 import { overwriteDomMethods, recoverDomMethods } from './overrideDom'
+import transformPropsKeys from './utils/transformPropsKeys'
 import { createPortal, version } from "react-dom"
 import ReactDOM from 'react-dom'
 
@@ -498,7 +499,7 @@ export default function applyReactInVue(component, options = {}) {
             }
           },
           attrs: () => {
-            this.__veauryLast__.attrs = this.$attrs
+            this.__veauryLast__.attrs = transformPropsKeys(this.$attrs)
           }
         }
         if (updateType) {
@@ -517,7 +518,7 @@ export default function applyReactInVue(component, options = {}) {
           const Component = createReactContainer(component, options, this)
           let reactRootComponent = <Component
             // __veauryVueProviderList__={this.__veauryVueProviderList__}
-            {...toRaws(this.$attrs)}
+            {...transformPropsKeys(toRaws(this.$attrs))}
             {...toRaws(this.__veauryInjectedProps__)}
             {...{ children }}
             {...lastNormalSlots}

--- a/src/pureReactInVue/getChildInfo.js
+++ b/src/pureReactInVue/getChildInfo.js
@@ -1,4 +1,5 @@
 import {formatClass, formatStyle} from '../utils/styleClassTransformer'
+import transformPropsKeys from '../utils/transformPropsKeys'
 import options from '../options'
 // import RenderReactNode from './RenderReactNode'
 
@@ -34,10 +35,7 @@ export default function getChildInfo(child, index, vueInReactCall, defaultSlotsF
   if (Object.keys(style).length > 0) newProps.style = style
   if (className !== '') newProps.className = className
 
-  Object.assign(props, {
-    ...newProps,
-    ...reactScoped,
-  })
+  Object.assign(props, newProps)
   delete props.class
 
   // if (child.type === RenderReactNode) {
@@ -48,5 +46,5 @@ export default function getChildInfo(child, index, vueInReactCall, defaultSlotsF
   // remove ref_for
   if (typeof props.ref_for === "boolean") delete props.ref_for
 
-  return props
+  return { ...transformPropsKeys(props), ...reactScoped }
 }

--- a/src/utils/transformPropsKeys.js
+++ b/src/utils/transformPropsKeys.js
@@ -1,0 +1,14 @@
+import toCamelCase from './toCamelCase'
+
+export default function transformPropsKeys(props) {
+  if (!props) return props
+  const result = {}
+  for (const [key, value] of Object.entries(props)) {
+    if (!key.includes('-') || key.startsWith('aria-') || key.startsWith('data-')) {
+      result[key] = value
+    } else {
+      result[toCamelCase(key)] = value
+    }
+  }
+  return result
+}

--- a/tests/cases/applyReactInVue/5-kebabCaseAttrs-test.js
+++ b/tests/cases/applyReactInVue/5-kebabCaseAttrs-test.js
@@ -1,0 +1,29 @@
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent, waitFor } from '@testing-library/vue'
+import KebabCaseAttrs from './5-kebabCaseAttrs'
+import KebabCaseAttrsUpdate from './5-kebabCaseAttrs-update'
+import KebabCaseAttrsWrapped from './5-kebabCaseAttrs-wrapped'
+
+test('applyReactInVue maps kebab-case attrs to camelCase props', async () => {
+  render(KebabCaseAttrs)
+  expect(await screen.findByTestId('myProp')).toHaveTextContent('value')
+  expect(await screen.findByTestId('anotherProp')).toHaveTextContent('value')
+  expect(await screen.findByTestId('aria-label')).toHaveTextContent('value')
+  expect(await screen.findByTestId('data-foo')).toHaveTextContent('value')
+  expect(await screen.findByTestId('alreadyCamel')).toHaveTextContent('value')
+})
+
+test('applyReactInVue maps kebab-case attrs when wrapped inside another applyReactInVue', async () => {
+  render(KebabCaseAttrsWrapped)
+  expect(await screen.findByTestId('myProp')).toHaveTextContent('value')
+  expect(await screen.findByTestId('anotherProp')).toHaveTextContent('value')
+})
+
+test('applyReactInVue updates transformed attrs reactively', async () => {
+  render(KebabCaseAttrsUpdate)
+  expect(await screen.findByTestId('myProp')).toHaveTextContent('value')
+  await fireEvent.click(await screen.findByTestId('update-btn'))
+  await waitFor(async () => {
+    expect(await screen.findByTestId('myProp')).toHaveTextContent('new-value')
+  })
+})

--- a/tests/cases/applyReactInVue/5-kebabCaseAttrs-update.vue
+++ b/tests/cases/applyReactInVue/5-kebabCaseAttrs-update.vue
@@ -1,0 +1,13 @@
+<template>
+  <Component :my-prop="dynamicProp" />
+  <button data-testid="update-btn" @click="dynamicProp = 'new-value'">update</button>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { applyReactInVue } from 'veaury'
+import KebabCaseAttrsComponent from './KebabCaseAttrsComponent'
+
+const Component = applyReactInVue(KebabCaseAttrsComponent)
+const dynamicProp = ref('value')
+</script>

--- a/tests/cases/applyReactInVue/5-kebabCaseAttrs-wrapped.vue
+++ b/tests/cases/applyReactInVue/5-kebabCaseAttrs-wrapped.vue
@@ -1,0 +1,13 @@
+<template>
+  <ParentInVue>
+    <ChildInVue my-prop="value" another-prop="value" />
+  </ParentInVue>
+</template>
+
+<script setup>
+import { applyReactInVue } from 'veaury'
+import KebabCaseAttrsComponent from './KebabCaseAttrsComponent'
+
+const ParentInVue = applyReactInVue(({ children }) => children)
+const ChildInVue = applyReactInVue(KebabCaseAttrsComponent)
+</script>

--- a/tests/cases/applyReactInVue/5-kebabCaseAttrs.vue
+++ b/tests/cases/applyReactInVue/5-kebabCaseAttrs.vue
@@ -1,0 +1,16 @@
+<template>
+  <Component
+    my-prop="value"
+    another-prop="value"
+    aria-label="value"
+    data-foo="value"
+    already-camel="value"
+  />
+</template>
+
+<script setup>
+import { applyReactInVue } from 'veaury'
+import KebabCaseAttrsComponent from './KebabCaseAttrsComponent'
+
+const Component = applyReactInVue(KebabCaseAttrsComponent)
+</script>

--- a/tests/cases/applyReactInVue/KebabCaseAttrsComponent.js
+++ b/tests/cases/applyReactInVue/KebabCaseAttrsComponent.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default function KebabCaseAttrsComponent(props) {
+  return (
+    <div data-testid="prop-capture">
+      <span data-testid="myProp">{props.myProp ?? ''}</span>
+      <span data-testid="anotherProp">{props.anotherProp ?? ''}</span>
+      <span data-testid="aria-label">{props['aria-label'] ?? ''}</span>
+      <span data-testid="data-foo">{props['data-foo'] ?? ''}</span>
+      <span data-testid="alreadyCamel">{props.alreadyCamel ?? ''}</span>
+    </div>
+  )
+}

--- a/tests/cases/pureReactInVue/2-kebabCaseAttrs-test.js
+++ b/tests/cases/pureReactInVue/2-kebabCaseAttrs-test.js
@@ -1,0 +1,29 @@
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent, waitFor } from '@testing-library/vue'
+import KebabCaseAttrs from './2-kebabCaseAttrs'
+import KebabCaseAttrsUpdate from './2-kebabCaseAttrs-update'
+import KebabCaseAttrsWrapped from './2-kebabCaseAttrs-wrapped'
+
+test('applyPureReactInVue maps kebab-case attrs to camelCase props', async () => {
+  render(KebabCaseAttrs)
+  expect(await screen.findByTestId('myProp')).toHaveTextContent('value')
+  expect(await screen.findByTestId('anotherProp')).toHaveTextContent('value')
+  expect(await screen.findByTestId('aria-label')).toHaveTextContent('value')
+  expect(await screen.findByTestId('data-foo')).toHaveTextContent('value')
+  expect(await screen.findByTestId('alreadyCamel')).toHaveTextContent('value')
+})
+
+test('applyPureReactInVue maps kebab-case attrs when wrapped inside another applyPureReactInVue', async () => {
+  render(KebabCaseAttrsWrapped)
+  expect(await screen.findByTestId('myProp')).toHaveTextContent('value')
+  expect(await screen.findByTestId('anotherProp')).toHaveTextContent('value')
+})
+
+test('applyPureReactInVue updates transformed attrs reactively', async () => {
+  render(KebabCaseAttrsUpdate)
+  expect(await screen.findByTestId('myProp')).toHaveTextContent('value')
+  await fireEvent.click(await screen.findByTestId('update-btn'))
+  await waitFor(async () => {
+    expect(await screen.findByTestId('myProp')).toHaveTextContent('new-value')
+  })
+})

--- a/tests/cases/pureReactInVue/2-kebabCaseAttrs-update.vue
+++ b/tests/cases/pureReactInVue/2-kebabCaseAttrs-update.vue
@@ -1,0 +1,13 @@
+<template>
+  <Component :my-prop="dynamicProp" />
+  <button data-testid="update-btn" @click="dynamicProp = 'new-value'">update</button>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { applyPureReactInVue } from 'veaury'
+import KebabCaseAttrsComponent from './KebabCaseAttrsComponent'
+
+const Component = applyPureReactInVue(KebabCaseAttrsComponent)
+const dynamicProp = ref('value')
+</script>

--- a/tests/cases/pureReactInVue/2-kebabCaseAttrs-wrapped.vue
+++ b/tests/cases/pureReactInVue/2-kebabCaseAttrs-wrapped.vue
@@ -1,0 +1,13 @@
+<template>
+  <ParentInVue>
+    <ChildInVue my-prop="value" another-prop="value" />
+  </ParentInVue>
+</template>
+
+<script setup>
+import { applyPureReactInVue } from 'veaury'
+import KebabCaseAttrsComponent from './KebabCaseAttrsComponent'
+
+const ParentInVue = applyPureReactInVue(({ children }) => children)
+const ChildInVue = applyPureReactInVue(KebabCaseAttrsComponent)
+</script>

--- a/tests/cases/pureReactInVue/2-kebabCaseAttrs.vue
+++ b/tests/cases/pureReactInVue/2-kebabCaseAttrs.vue
@@ -1,0 +1,16 @@
+<template>
+  <Component
+    my-prop="value"
+    another-prop="value"
+    aria-label="value"
+    data-foo="value"
+    already-camel="value"
+  />
+</template>
+
+<script setup>
+import { applyPureReactInVue } from 'veaury'
+import KebabCaseAttrsComponent from './KebabCaseAttrsComponent'
+
+const Component = applyPureReactInVue(KebabCaseAttrsComponent)
+</script>

--- a/tests/cases/pureReactInVue/KebabCaseAttrsComponent.js
+++ b/tests/cases/pureReactInVue/KebabCaseAttrsComponent.js
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default function KebabCaseAttrsComponent(props) {
+  return (
+    <div data-testid="prop-capture">
+      <span data-testid="myProp">{props.myProp ?? ''}</span>
+      <span data-testid="anotherProp">{props.anotherProp ?? ''}</span>
+      <span data-testid="aria-label">{props['aria-label'] ?? ''}</span>
+      <span data-testid="data-foo">{props['data-foo'] ?? ''}</span>
+      <span data-testid="alreadyCamel">{props.alreadyCamel ?? ''}</span>
+    </div>
+  )
+}

--- a/tests/cases/utils/1-test.js
+++ b/tests/cases/utils/1-test.js
@@ -5,6 +5,7 @@
 import couldBeClass from "src/utils/couldBeClass";
 import { formatClass, formatStyle } from "src/utils/styleClassTransformer";
 import parseVModel from "src/utils/parseVModel";
+import transformPropsKeys from "src/utils/transformPropsKeys";
 
 describe('Test utils', () => {
 
@@ -57,5 +58,13 @@ describe('Test utils', () => {
         'v-models': 1
       })
     }).toThrow()
+  })
+
+  test('Test transformPropsKeys.js', () => {
+    expect(transformPropsKeys({ 'my-prop': 'a', 'another-prop': 'b' })).toEqual({ myProp: 'a', anotherProp: 'b' })
+    expect(transformPropsKeys({ 'aria-label': 'x', 'data-foo': 'y' })).toEqual({ 'aria-label': 'x', 'data-foo': 'y' })
+    expect(transformPropsKeys({ alreadyCamel: 'z' })).toEqual({ alreadyCamel: 'z' })
+    expect(transformPropsKeys(null)).toBe(null)
+    expect(transformPropsKeys(undefined)).toBe(undefined)
   })
 })


### PR DESCRIPTION
We enforce `kebab-case` in our Vue codebase thus we have to automatically convert it to `camelCase` so it matches. This PR implements this change. This is a soft-breaking change if someone relied on React props containing a `-` (aside from `data-` and `aria-` props) to be forwarded as-is. I'm saying soft-breaking as this is quite against usual React conventions. I'm also to add a configuration option that this change would be opt-in (or opt-out if the conversion makes sense as a default). Let me know if you want to accept this PR as-is or want more changes.